### PR TITLE
You can send empty null messages to kafka

### DIFF
--- a/src/main/java/com/ruckuswireless/pentaho/kafka/producer/KafkaProducerStep.java
+++ b/src/main/java/com/ruckuswireless/pentaho/kafka/producer/KafkaProducerStep.java
@@ -25,7 +25,11 @@ import org.pentaho.di.trans.step.StepMetaInterface;
  * @author Michael Spector
  */
 public class KafkaProducerStep extends BaseStep implements StepInterface {
+
 	private final static byte[] getUTFBytes(String source) {
+		if (source == null) {
+			return null;
+		}
 		try {
 			return source.getBytes("UTF-8");
 		} catch (UnsupportedEncodingException e) {


### PR DESCRIPTION
By documentation you can send messages to Kafka with null payload. For example for Log Compaction https://cwiki.apache.org/confluence/display/KAFKA/Log+Compaction