### PR TITLE
More flexible build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,11 @@ Apache Kafka producer step plug-in for Pentaho Kettle.
 
 ### Apache Kafka Compatibility ###
 
-The producer depends on Apache Kafka 0.8.1.1, which means that the broker must be of 0.8.x version or later.
+By default the producer depends on Apache Kafka 0.8.1.1, which means that the broker must be of 0.8.x version or later.
+
+If you want to build the plugin for a different Kafka version you have to
+modify the kafka.version and kafka.scala.version in the properties section
+of the pom.xml. 
 
 
 ### Installation ###

--- a/assembly.xml
+++ b/assembly.xml
@@ -3,6 +3,8 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
 
+        <id>dist</id>
+        
 	<baseDirectory>${project.artifactId}</baseDirectory>
 
 	<formats>
@@ -16,30 +18,13 @@
 			</includes>
 		</fileSet>
 		<fileSet>
-			<directory>target/lib</directory>
-			<outputDirectory>lib</outputDirectory>
-			<includes>
-				<include>jline-0.9.94.jar</include>
-				<include>jopt-simple-3.2.jar</include>
-				<include>junit-3.8.1.jar</include>
-				<include>kafka_2.10-0.8.2.1.jar</include>
-				<include>kafka-clients-0.8.2.1.jar</include>
-				<include>lz4-1.2.0.jar</include>
-				<include>metrics-core-2.2.0.jar</include>
-				<include>netty-3.7.0.Final.jar</include>
-				<include>scala-library-2.10.4.jar</include>
-				<include>snappy-java-1.1.1.6.jar</include>
-				<include>zkclient-0.3.jar</include>
-				<include>zookeeper-3.4.6.jar</include>
-			</includes>
-		</fileSet>
-		<fileSet>
 			<directory>target</directory>
 			<outputDirectory>.</outputDirectory>
-			<includes>
-				<include>*.jar</include>
-				<include>version.xml</include>
-			</includes>
+                        <includes>
+                            <include>*.jar</include>
+                            <include>version.xml</include>
+                            <include>lib/*.jar</include>
+                        </includes>
 		</fileSet>
 	</fileSets>
 </assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -5,13 +5,15 @@
 	<groupId>com.ruckuswireless</groupId>
 	<artifactId>pentaho-kafka-producer</artifactId>
 	<version>TRUNK-SNAPSHOT</version>
-	<name>Apache Kafka Integration Plug-In for Pentaho</name>
+	<name>Apache Kafka Producer Plug-In for Pentaho</name>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.target>1.6</maven.compiler.target>
 		<maven.compiler.source>1.6</maven.compiler.source>
-        <kettle.version>6.1.0.2-208</kettle.version>
+                <kettle.version>6.1.0.2-208</kettle.version>
+                <kafka.scala.version>2.11</kafka.scala.version>
+                <kafka.version>0.10.2.1</kafka.version>
 		<buildId>${maven.build.timestamp}</buildId>
 		<maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
 	</properties>
@@ -30,8 +32,8 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
-			<artifactId>kafka_2.10</artifactId>
-			<version>0.8.2.1</version>
+			<artifactId>kafka_${kafka.scala.version}</artifactId>
+			<version>${kafka.version}</version>
 			<exclusions>
 				<exclusion>
 					<groupId>com.sun.jmx</groupId>
@@ -45,31 +47,31 @@
 					<groupId>javax.jms</groupId>
 					<artifactId>jms</artifactId>
 				</exclusion>
-			</exclusions>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-api</artifactId>
+				</exclusion>
+                        </exclusions>
 		</dependency>
 		<dependency>
 			<groupId>pentaho-kettle</groupId>
 			<artifactId>kettle-engine</artifactId>
 			<version>${kettle.version}</version>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>pentaho-kettle</groupId>
-			<artifactId>kettle-core</artifactId>
-			<version>${kettle.version}</version>
-			<scope>compile</scope>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>pentaho-kettle</groupId>
 			<artifactId>kettle-ui-swt</artifactId>
 			<version>${kettle.version}</version>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.swt</groupId>
-			<artifactId>org.eclipse.swt.win32.win32.x86_64</artifactId>
-			<version>4.3</version>
-			<scope>compile</scope>
+			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 
@@ -107,6 +109,8 @@
 							<goal>copy-dependencies</goal>
 						</goals>
 						<configuration>
+                                                        <excludeScope>provided</excludeScope>
+                                                        <includeScope>runtime</includeScope>
 							<outputDirectory>${project.build.directory}/lib</outputDirectory>
 						</configuration>
 					</execution>
@@ -135,36 +139,5 @@
 				</executions>
 			</plugin>
 		</plugins>
-
-		<pluginManagement>
-			<plugins>
-				<!-- Ignore/Execute plugin execution -->
-				<plugin>
-					<groupId>org.eclipse.m2e</groupId>
-					<artifactId>lifecycle-mapping</artifactId>
-					<version>1.0.0</version>
-					<configuration>
-						<lifecycleMappingMetadata>
-							<pluginExecutions>
-								<!-- copy-dependency plugin -->
-								<pluginExecution>
-									<pluginExecutionFilter>
-										<groupId>org.apache.maven.plugins</groupId>
-										<artifactId>maven-dependency-plugin</artifactId>
-										<versionRange>[1.0.0,)</versionRange>
-										<goals>
-											<goal>copy-dependencies</goal>
-										</goals>
-									</pluginExecutionFilter>
-									<action>
-										<ignore />
-									</action>
-								</pluginExecution>
-							</pluginExecutions>
-						</lifecycleMappingMetadata>
-					</configuration>
-				</plugin>
-			</plugins>
-		</pluginManagement>
 	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
 		<maven.compiler.target>1.6</maven.compiler.target>
 		<maven.compiler.source>1.6</maven.compiler.source>
                 <kettle.version>6.1.0.2-208</kettle.version>
-                <kafka.scala.version>2.11</kafka.scala.version>
-                <kafka.version>0.10.2.1</kafka.version>
+                <kafka.scala.version>2.10</kafka.scala.version>
+                <kafka.version>0.8.2.1</kafka.version>
 		<buildId>${maven.build.timestamp}</buildId>
 		<maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -139,5 +139,36 @@
 				</executions>
 			</plugin>
 		</plugins>
+
+		<pluginManagement>
+			<plugins>
+				<!-- Ignore/Execute plugin execution -->
+				<plugin>
+					<groupId>org.eclipse.m2e</groupId>
+					<artifactId>lifecycle-mapping</artifactId>
+					<version>1.0.0</version>
+					<configuration>
+						<lifecycleMappingMetadata>
+							<pluginExecutions>
+								<!-- copy-dependency plugin -->
+								<pluginExecution>
+									<pluginExecutionFilter>
+										<groupId>org.apache.maven.plugins</groupId>
+										<artifactId>maven-dependency-plugin</artifactId>
+										<versionRange>[1.0.0,)</versionRange>
+										<goals>
+											<goal>copy-dependencies</goal>
+										</goals>
+									</pluginExecutionFilter>
+									<action>
+										<ignore />
+									</action>
+								</pluginExecution>
+							</pluginExecutions>
+						</lifecycleMappingMetadata>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 	</build>
 </project>


### PR DESCRIPTION
This commit has some changes to the build script:

- Kafka and the Scala version can now be selected through the properties kafka.version and kafka.scala.version (addresses #12)
- The dependencies to copy are now controlled by scope and excludes in the dependency section of the pom.xml. It is not necessary anymore to list the dependencies in the assembly.xml.
- Unnecessary dependencies have been removed.
